### PR TITLE
Fix to refresh prompt when execute cd

### DIFF
--- a/aliases/cd
+++ b/aliases/cd
@@ -28,6 +28,7 @@ fn cd(path) {
 
        if $path == "" {
                chdir($HOME)
+               refreshPrompt()
                return
         }
 


### PR DESCRIPTION
Fix to when I execute a command cd the bash execute the refreshPrompt method.

λ> cd .nash/
git:(master)λ> pwd
/home/matheus/.nash
git:(master)λ> cd
git:(master)λ> pwd
/home/matheus
git:(master)λ> cd ../matheus/